### PR TITLE
feat: 카카오 소셜 로그인 구현 / 가입 / accessToken 재발급

### DIFF
--- a/src/main/java/commitcapstone/commit/oauth/entity/UserEntity.java
+++ b/src/main/java/commitcapstone/commit/oauth/entity/UserEntity.java
@@ -24,9 +24,6 @@ public class UserEntity {
     @Column(name = "oauth_id", nullable = false, unique = true, length = 100)
     private String oauthId; // 사용자의 해당 소셜 로그인 고유 아이디
 
-    @Column(nullable = false, unique = true)
-    private String email;
-
     @Column(nullable = false, length = 50)
     private String nickname; // 사용자 닉네임
 

--- a/src/main/java/commitcapstone/commit/oauth/google/controller/googleOauthController.java
+++ b/src/main/java/commitcapstone/commit/oauth/google/controller/googleOauthController.java
@@ -2,12 +2,12 @@ package commitcapstone.commit.oauth.google.controller;
 
 import commitcapstone.commit.oauth.google.dto.googleInfo;
 import commitcapstone.commit.oauth.google.dto.googleOauthAccessToken;
-import commitcapstone.commit.oauth.google.dto.googleOauthResponse;
 import commitcapstone.commit.oauth.google.dto.googleToken;
-import commitcapstone.commit.oauth.google.service.OauthService;
+import commitcapstone.commit.oauth.google.service.googleService;
 import commitcapstone.commit.oauth.repository.UserRepository;
 import jakarta.servlet.http.HttpSession;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,13 +15,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-
-public class OauthController {
-    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(OauthController.class);
-    private final OauthService oauthService;
+public class googleOauthController {
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(googleOauthController.class);
+    private final googleService oauthService;
     private final UserRepository userRepository;
 
-    public OauthController(OauthService oauthService, UserRepository userRepository) {
+    @Autowired
+    public googleOauthController(googleService oauthService, UserRepository userRepository) {
         this.oauthService = oauthService;
         this.userRepository = userRepository;
     }
@@ -33,29 +33,28 @@ public class OauthController {
         return ResponseEntity.ok(OauthURL);
     }
 
-
+    //todo : email로 회원가입여부를 확인하는게 아닌 id_token의 sub에 저장된 회원 아이디로 비교를 해야함(저장도 마찬가지)
     @GetMapping("oauth/google/redirect")
-    public ResponseEntity<googleOauthResponse> redirect(@RequestParam String code, HttpSession session) {
+    public ResponseEntity<googleToken> redirect(@RequestParam String code, HttpSession session) {
 
         googleToken token = oauthService.getGoogleToken(code);
         googleInfo info = oauthService.getGoogleInfo(token.getAccessToken());
 
 
-        String email = info.getEmail();
-        LOGGER.info(email);
-        boolean isExistingUser = userRepository.existsByEmail(email);
-        final String refreshToken = token.getRefreshToken();
 
+//        boolean isExistingUser = userRepository.existsByEmail(email);
+        final String refreshToken = token.getRefreshToken();
+//
         //세션에 RefreshToken 저장
         session.setAttribute("refreshToken", token.getRefreshToken());
         LOGGER.info("저장한 리프레시토큰 : " + refreshToken);
         LOGGER.info("세션 아이디 : " + session.getId());
-        googleOauthResponse response = new googleOauthResponse(
-                token.getAccessToken(),
-                isExistingUser //이미 가입된 회원인지 판단 true -> 가입된 회원 false -> 첫 가입 회원
-        );
+//        googleOauthResponse response = new googleOauthResponse(
+//                token.getAccessToken(),
+//                isExistingUser //이미 가입된 회원인지 판단 true -> 가입된 회원 false -> 첫 가입 회원
+//        );
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(token);
     }
 
     @PostMapping("oauth/google/token")

--- a/src/main/java/commitcapstone/commit/oauth/google/service/googleService.java
+++ b/src/main/java/commitcapstone/commit/oauth/google/service/googleService.java
@@ -1,7 +1,7 @@
 package commitcapstone.commit.oauth.google.service;
 
 
-import commitcapstone.commit.oauth.google.controller.OauthController;
+import commitcapstone.commit.oauth.google.controller.googleOauthController;
 import commitcapstone.commit.oauth.google.dto.googleInfo;
 import commitcapstone.commit.oauth.google.dto.googleOauthAccessToken;
 import commitcapstone.commit.oauth.google.dto.googleToken;
@@ -17,8 +17,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
-public class OauthService {
-    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(OauthController.class);
+public class googleService {
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(googleOauthController.class);
 
     @Value("${spring.oauth2.google.client-id}")
     private String clientId;
@@ -27,9 +27,7 @@ public class OauthService {
     @Value("${spring.oauth2.google.redirect-uri}")
     private String redirectUri;
     @Value("${spring.oauth2.google.scope[0]}")
-    private String scope_1;
-    @Value("${spring.oauth2.google.scope[1]}")
-    private String scope_2;
+    private String scope;
 
 
 
@@ -39,7 +37,7 @@ public class OauthService {
         String baseURL = "https://accounts.google.com/o/oauth2/v2/auth?";
         return UriComponentsBuilder.
                 fromUriString(baseURL)
-                .queryParam("scope",scope_1 + " " + scope_2)
+                .queryParam("scope", scope)
                 .queryParam("client_id", clientId)
                 .queryParam("redirect_uri", redirectUri)
                 .queryParam("response_type", "code")
@@ -70,6 +68,8 @@ public class OauthService {
                 .bodyToMono(googleToken.class).block();
     }
 
+    // todo : 지금 accesstoken 이용해서 api 호출하는 방식으로 email 구하고있는데 이러면 비용발생하니까
+    // id_token encoding 해서 email 구해오는 방식으로 리팩토링 필요
 
     public googleInfo getGoogleInfo(String accessToken) {
         String baseURL = "https://www.googleapis.com/oauth2/v3/userinfo";
@@ -91,7 +91,6 @@ public class OauthService {
         WebClient client = WebClient.builder()
                 .baseUrl(baseURL)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
                 .build();
 
 

--- a/src/main/java/commitcapstone/commit/oauth/kakao/controller/kakaoOauthController.java
+++ b/src/main/java/commitcapstone/commit/oauth/kakao/controller/kakaoOauthController.java
@@ -1,0 +1,54 @@
+package commitcapstone.commit.oauth.kakao.controller;
+
+import commitcapstone.commit.oauth.google.dto.googleOauthAccessToken;
+import commitcapstone.commit.oauth.google.service.googleService;
+import commitcapstone.commit.oauth.kakao.dto.kakaoOauthAccessToken;
+import commitcapstone.commit.oauth.kakao.dto.kakaoToken;
+import commitcapstone.commit.oauth.kakao.service.kakaoService;
+import jakarta.servlet.http.HttpSession;
+import org.apache.coyote.Response;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class kakaoOauthController {
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(kakaoOauthController.class);
+    private final kakaoService oauthService;
+
+    public kakaoOauthController(kakaoService oauthService) {
+        this.oauthService = oauthService;
+    }
+
+
+    @GetMapping("/oauth/kakao/login")
+    public ResponseEntity<String> login() {
+        String OauthURL = oauthService.createOauthURL();
+
+        return ResponseEntity.ok(OauthURL);
+    }
+
+    @GetMapping("/oauth/kakao/redirect")
+    public ResponseEntity<kakaoToken> redirect(@RequestParam String code, HttpSession session) {
+        kakaoToken token = oauthService.getkakaoToken(code);
+        final String refreshToken = token.getRefreshToken();
+        session.setAttribute("refreshToken", token.getRefreshToken());
+        LOGGER.info("저장한 리프레시토큰 : " + refreshToken);
+        LOGGER.info("세션 아이디 : " + session.getId());
+        return ResponseEntity.ok(token);
+    }
+
+    @PostMapping("oauth/kakao/token")
+    public kakaoOauthAccessToken refresh(HttpSession session) {
+        String refreshToken = (String) session.getAttribute("refreshToken");
+        LOGGER.info("꺼낸 리프레시토큰 : " + refreshToken);
+        LOGGER.info("세션 아이디 : " + session.getId());
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            throw new RuntimeException("세션에 저장된 refreshToken 비어있음");
+        }
+        return oauthService.getkakaoAccesstoken(refreshToken);
+    }
+}

--- a/src/main/java/commitcapstone/commit/oauth/kakao/dto/kakaoOauthAccessToken.java
+++ b/src/main/java/commitcapstone/commit/oauth/kakao/dto/kakaoOauthAccessToken.java
@@ -1,0 +1,15 @@
+package commitcapstone.commit.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class kakaoOauthAccessToken {
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+}

--- a/src/main/java/commitcapstone/commit/oauth/kakao/dto/kakaoToken.java
+++ b/src/main/java/commitcapstone/commit/oauth/kakao/dto/kakaoToken.java
@@ -1,0 +1,29 @@
+package commitcapstone.commit.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class kakaoToken {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("expires_in")
+    private long expiresIn;
+
+    @JsonProperty("refresh_token_expires_in")
+    private long refreshExpiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("scope")
+    private String scope;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("id_token")
+    private String idToken;
+}

--- a/src/main/java/commitcapstone/commit/oauth/kakao/service/kakaoService.java
+++ b/src/main/java/commitcapstone/commit/oauth/kakao/service/kakaoService.java
@@ -1,0 +1,82 @@
+package commitcapstone.commit.oauth.kakao.service;
+
+
+import commitcapstone.commit.oauth.google.dto.googleOauthAccessToken;
+import commitcapstone.commit.oauth.kakao.dto.kakaoOauthAccessToken;
+import commitcapstone.commit.oauth.kakao.dto.kakaoToken;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+public class kakaoService {
+    @Value("${spring.oauth2.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.oauth2.kakao.redirect-url}")
+    private String redirectUri;
+
+    @Value("${spring.oauth2.kakao.scope[0]}")
+    private String scope;
+
+    public String createOauthURL() {
+        String baseURL = "https://kauth.kakao.com/oauth/authorize?";
+
+        return UriComponentsBuilder.
+                fromUriString(baseURL)
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("response_type", "code")
+                .queryParam("scope", scope + " openid")
+                .toUriString();
+    }
+
+    public kakaoToken getkakaoToken(String code) {
+        String baseURL = "https://kauth.kakao.com/oauth/token";
+        WebClient client = WebClient.builder()
+                .baseUrl(baseURL)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_UTF8_VALUE)
+                .build();
+
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("grant_type", "authorization_code");
+        formData.add("code", code);
+        formData.add("client_id", clientId);
+        formData.add("redirect_uri", redirectUri);
+
+
+
+
+        return client.post()
+                .body(BodyInserters.fromFormData(formData))
+                .retrieve()
+                .bodyToMono(kakaoToken.class).block();
+    }
+
+    public kakaoOauthAccessToken getkakaoAccesstoken(String refreshToken) {
+        String baseURL = "https://kauth.kakao.com/oauth/token";
+        WebClient client = WebClient.builder()
+                .baseUrl(baseURL)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_UTF8_VALUE)
+                .build();
+
+
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("client_id", clientId);
+        formData.add("grant_type", "refresh_token");
+        formData.add("refresh_token", refreshToken);
+
+
+
+        return client.post()
+                .body(BodyInserters.fromFormData(formData))
+                .retrieve()
+                .bodyToMono(kakaoOauthAccessToken.class).block();
+    }
+}

--- a/src/main/java/commitcapstone/commit/oauth/repository/UserRepository.java
+++ b/src/main/java/commitcapstone/commit/oauth/repository/UserRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
-    boolean existsByEmail(String email);
+//    boolean existsByEmail(String email);
 
 }


### PR DESCRIPTION
/oauth/kakao/login Get 요청 -> 카카오 소셜 로그인 URL 반환

로그인 완료 후 콜백 -> /oauth/kakao/redirect -> accessToken제공, refreshToken 세션 저장

/oauth/kakao/token -> refreshToken으로 accessToken 카카오에서 재발급